### PR TITLE
Add min_duration to get_latest_games, where it was missing

### DIFF
--- a/R/get_latest_games.R
+++ b/R/get_latest_games.R
@@ -33,7 +33,7 @@ get_latest_games <- function(num_games,
 
     # Use api status to obtain the 10 latest games parsed.
     api_status <- jsonlite::fromJSON("https://api.opendota.com/api/status")
-    game_list <- api_status$last_parsed$match_id
+    game_list <- subset(api_status$last_parsed, duration > min_duration)$match_id
 
     # Remove all previously parsed games (there can be duplicates if it's a slow day)
     game_list <- game_list[!(game_list %in% match_id_list)]

--- a/R/get_latest_games.R
+++ b/R/get_latest_games.R
@@ -30,7 +30,7 @@ get_latest_games <- function(num_games,
 
   # Check min_duration is not too high, otherwise you risk waiting forever for games
   if (min_duration > 80 * 60) {
-    cat(\r Warning: minimum duration is more than 80 minutes, it might take a while to obtain valid games)
+    cat("\r Warning: minimum duration is more than 80 minutes, it might take a while to obtain valid games")
   }
 
   # Run while loop for as long as needed to obtain number of matches required

--- a/R/get_latest_games.R
+++ b/R/get_latest_games.R
@@ -28,6 +28,11 @@ get_latest_games <- function(num_games,
   match_id_list <- c()
   all_parsed_games <- list()
 
+  # Check min_duration is not too high, otherwise you risk waiting forever for games
+  if (min_duration > 80 * 60) {
+    cat(\r Warning: minimum duration is more than 80 minutes, it might take a while to obtain valid games)
+  }
+
   # Run while loop for as long as needed to obtain number of matches required
   while(matches_parsed <= num_games) {
 


### PR DESCRIPTION
Pretty much as title. Noticed the `min_duration` was not doing anything, so I added a `subset` to enable it.
One issue is that if you pass a very high `min_duration`, it will sit there forever waiting for games. I added a warning for this.